### PR TITLE
Added run-aura-cli

### DIFF
--- a/makefile
+++ b/makefile
@@ -31,6 +31,10 @@ run-aura: aura
 	@cd ../aura && make -s run
 
 .PHONY:
+run-aura-cli: aura
+	@cd ../aura && make -s run-cli
+
+.PHONY:
 run-linux: mish-linux
 	@cd ../mish-linux && build/mish
 


### PR DESCRIPTION
Runs Aura from the project-asiago folder using curses, allowing for command line testing. Just a new rule in Aura and Project Asiago's makefiles, adding the -curses flag to QEMU.